### PR TITLE
Add support for command line access in other apps

### DIFF
--- a/YogMinify/Classes/HandleArgs.cs
+++ b/YogMinify/Classes/HandleArgs.cs
@@ -44,6 +44,7 @@ namespace YogMinify
         public static int test = 0;                      // Test mode, no changes done to files.
         public static int skipwarnings = 0;              // Skip warnings and continue operation.
         public static bool showLibraries = false;        // TODO: Show minify library information.
+        public static bool enableCmdAccessFromOtherApps = false;             // Stops setting Console.CursorVisible to enable other applications to use YogMinify as a process
         public static bool showHelp = false;             // TODO: Show usage and arguments help.
         private static List<string> inputFiles;          // List containing input files found in command line.
 
@@ -85,6 +86,8 @@ namespace YogMinify
                    v => { if (v != null) ++test; } },
                 { "y|skipwarnings", "Skips warnings (like when you're about to minify lots of files) and continues operation.",
                    v => { if (v != null) ++skipwarnings; } },
+                { "c|cmd",  "Enables other applications to use YogMinify as a process.",
+                   v => enableCmdAccessFromOtherApps = v != null },
                 { "h|help",  "Show this message and exit.",
                    v => showHelp = v != null },
             };

--- a/YogMinify/Program.cs
+++ b/YogMinify/Program.cs
@@ -41,9 +41,6 @@ namespace YogMinify
             DateTime buildDate = new DateTime(2000, 1, 1).AddDays(version.Build).AddSeconds(version.Revision * 2);
             string displayableVersion = $"{version} ({buildDate})";
 
-            // Hide console cursor during normal operation.
-            Console.CursorVisible = false;
-
             // Set window title.
             var windowTitle = "YogMinify v" + displayableVersion;
             Console.Title = windowTitle;
@@ -51,6 +48,12 @@ namespace YogMinify
             // Get list of input files from parsed raw arguments.
             List<string> extra = HandleArgs.GetRawArgs(args);
             string[] files = extra.ToArray();
+
+            if (!HandleArgs.enableCmdAccessFromOtherApps)
+            {
+                // Hide console cursor during normal operation.
+                Console.CursorVisible = false;
+            }
 
             // If no files supplied or help argument supplied, abort and send help.
             if (files.Length < 1 || HandleArgs.showHelp)


### PR DESCRIPTION
Other .Net applications error when the Console.CursorVisible property is
 set. This commit adds an argument that can be used to prevent that error
 when YogMinify is called from Process.Start in other .Net applications.